### PR TITLE
Simple improvements

### DIFF
--- a/Ganalytics/Ganalytics.h
+++ b/Ganalytics/Ganalytics.h
@@ -25,6 +25,8 @@ typedef NS_ENUM(NSInteger, GANDefaultParameter) {
 
 - (instancetype)initWithTrackingID:(NSString *)trackingID NS_DESIGNATED_INITIALIZER;
 
+- (void)sendRequestWithParameters:(NSDictionary *)parameters;
+
 - (void)sendEventWithCategory:(NSString *)category  // required
                        action:(NSString *)action    // required
                         label:(NSString *)label     // optional

--- a/Ganalytics/Ganalytics.h
+++ b/Ganalytics/Ganalytics.h
@@ -25,8 +25,6 @@ typedef NS_ENUM(NSInteger, GANDefaultParameter) {
 
 - (instancetype)initWithTrackingID:(NSString *)trackingID NS_DESIGNATED_INITIALIZER;
 
-- (void)sendRequestWithParameters:(NSDictionary *)parameters;
-
 - (void)sendEventWithCategory:(NSString *)category  // required
                        action:(NSString *)action    // required
                         label:(NSString *)label     // optional
@@ -50,5 +48,7 @@ typedef NS_ENUM(NSInteger, GANDefaultParameter) {
                          value:(NSInteger)value;
 
 - (void)setValue:(id)value forDefaultParameter:(GANDefaultParameter)parameter;  // use this method to override default parameters
+
+- (void)sendRequestWithParameters:(NSDictionary *)parameters;
 
 @end

--- a/Ganalytics/Ganalytics.h
+++ b/Ganalytics/Ganalytics.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+#define SUPPORT_IDFA	// Leaving this not commented means you've to declare you're using IDFA when submitting
+
 typedef NS_ENUM(NSInteger, GANDefaultParameter) {
     GANApplicationID,
     GANApplicationName,
@@ -18,8 +20,10 @@ typedef NS_ENUM(NSInteger, GANDefaultParameter) {
 
 @property (nonatomic, strong) NSString *trackingID;
 
-@property (nonatomic, assign) BOOL useSSL;      // YES by default
-@property (nonatomic, assign) BOOL debugMode;   // NO by deafult
+@property (nonatomic, assign) BOOL useSSL;				// YES by default
+@property (nonatomic, assign) BOOL debugMode;   		// NO by default
+@property (nonatomic, assign) BOOL allowIDFACollection;	// NO by default
+
 
 + (instancetype)sharedInstance;
 

--- a/Ganalytics/Ganalytics.h
+++ b/Ganalytics/Ganalytics.h
@@ -10,6 +10,16 @@
 
 #define SUPPORT_IDFA	// Leaving this not commented means you've to declare you're using IDFA when submitting
 
+// From http://holko.pl/2015/05/31/weakify-strongify/
+#define weakify(var) __weak typeof(var) AHKWeak_##var = var;
+
+#define strongify(var) \
+	_Pragma("clang diagnostic push") \
+	_Pragma("clang diagnostic ignored \"-Wshadow\"") \
+	__strong typeof(var) var = AHKWeak_##var; \
+	_Pragma("clang diagnostic pop")
+
+
 typedef NS_ENUM(NSInteger, GANDefaultParameter) {
     GANApplicationID,
     GANApplicationName,

--- a/Ganalytics/Ganalytics.m
+++ b/Ganalytics/Ganalytics.m
@@ -401,8 +401,13 @@
 - (NSString *)gan_queryString {
     NSMutableArray *parameters = [NSMutableArray array];
     for (id key in self) {
-        id value = [self objectForKey:key];
-        NSString *parameter = [[NSString stringWithFormat: @"%@=%@", key, value] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+		NSString	*value	= (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+																									(CFStringRef)[[self objectForKey: key] description],
+																									NULL,
+																									CFSTR("!*'();:@&=+$,/?%#[]"),
+																									kCFStringEncodingUTF8);
+		
+        NSString *parameter = [NSString stringWithFormat: @"%@=%@", key, value];
         [parameters addObject:parameter];
     }
     return [parameters componentsJoinedByString:@"&"];


### PR DESCRIPTION
- Made the generic sendRequestWithParameters: public, in order to deal with special requests (like session start)
- Added optional support for iOS 6
- Added simple persistent storage for requests when offline: requests are stored on disk when app becomes inactive and re-queued when connection is available again
